### PR TITLE
Added Xcopa

### DIFF
--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -105,6 +105,9 @@ task_metrics:
   bigbench_operators_generate_until: exact_match
   bigbench_repeat_copy_logic_generate_until: exact_match
   bigbench_cs_algorithms_generate_until: exact_match
+  xcopa:et: acc
+  xcopa:it: acc
+  xcopa:tr: acc
   global_piqa_completions_als_latn: acc_norm
   global_piqa_completions_bos_latn: acc_norm
   global_piqa_completions_bul_cyrl: acc_norm
@@ -446,6 +449,16 @@ task_groups:
         n_shots: [10]
         dataset: openeurollm/jeopardy
 
+  xcopa-eu:
+    description: "XCOPA commonsense causal reasoning (0-shot) for EU languages."
+    suite: lighteval
+    n_shots: [0]
+    dataset: cambridgeltl/xcopa
+    valid_langs: [et, it, tr]
+    tasks:
+      - task: "xcopa:{lang}"
+        subset: "{lang}"
+
   arc-challenge-mt-eu:
     description: "ARC Challenge multilingual (22 European languages)"
     suite: lm-eval-harness
@@ -519,3 +532,4 @@ super_groups:
       - task: mgsm-eu
       - task: generic-multilingual
       - task: include
+      - task: xcopa-eu


### PR DESCRIPTION
## Summary

I added **`xcopa-eu`**, the [XCOPA](https://github.com/cambridgeltl/xcopa) cross-lingual commonsense causal-reasoning benchmark, wired to the built-in **lighteval** `xcopa:{lang}` tasks at 0-shot. One of the Evals from #89.

## Language coverage — EU subset only

XCOPA ships only three languages that are in our EU set, and I include all of them:

> Estonian (`xcopa:et`), Italian (`xcopa:it`), Turkish (`xcopa:tr`)

The remaining XCOPA languages (Haitian Creole, Indonesian, Quechua, Swahili, Tamil, Thai, Vietnamese, Chinese) are non-EU, so they're omitted. The group is a `{lang}` template with `valid_langs: [et, it, tr]`; the two-letter subsets fold to their canonical `lang_Scri` codes (`est_Latn`, `ita_Latn`, `tur_Latn`) via the existing `_LANG_ALIAS`, so bracket scoping (`xcopa-eu[ita_Latn]`) and `oellm-multilingual` language filtering resolve correctly.

## Metric

`acc` — matching lighteval's `loglikelihood_acc` for the classic `xcopa:*` tasks.