### PR TITLE
add MMMLU

### DIFF
--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -1,5 +1,10 @@
 task_metrics:
   mmlu: acc
+  mmmlu_de_de: acc
+  mmmlu_es_la: acc
+  mmmlu_fr_fr: acc
+  mmmlu_it_it: acc
+  mmmlu_pt_br: acc
   sib200_bul_Cyrl: acc_norm
   sib200_hrv_Latn: acc_norm
   sib200_ces_Latn: acc_norm
@@ -296,6 +301,23 @@ task_groups:
         subset: es
       - task: mgsm_native_cot_fr
         subset: fr
+
+  mmmlu-eu:
+    description: "MMMLU (human-translated MMLU), EU subset, 5-shot acc."
+    suite: lm-eval-harness
+    n_shots: [5]
+    dataset: openai/MMMLU
+    tasks:
+      - task: mmmlu_de_de
+        subset: DE_DE
+      - task: mmmlu_es_la
+        subset: ES_LA
+      - task: mmmlu_fr_fr
+        subset: FR_FR
+      - task: mmmlu_it_it
+        subset: IT_IT
+      - task: mmmlu_pt_br
+        subset: PT_BR
 
   generic-multilingual:
     description: "Generic multilingual benchmarks in Aya Expanse"

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -44,6 +44,12 @@ _LANG_ALIAS = {
     "sl": "slv_Latn",
     "is": "isl_Latn",
     "nb": "nob_Latn",
+    # openai/MMMLU locale codes (lang_REGION)
+    "de_de": "deu_Latn",
+    "es_la": "spa_Latn",
+    "fr_fr": "fra_Latn",
+    "it_it": "ita_Latn",
+    "pt_br": "por_Latn",
     # full English names (include)
     "albanian": "als_Latn",
     "armenian": "hye_Armn",

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -23,7 +23,7 @@ from oellm.task_groups import (
 
 # Multilingual groups still defined with explicit per-language task lists
 # (not {lang} templates) whose tasks must also resolve to a language.
-EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include"]
+EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "mmmlu-eu", "include"]
 
 
 def _raw_yaml() -> dict:

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -23,7 +23,14 @@ from oellm.task_groups import (
 
 # Multilingual groups still defined with explicit per-language task lists
 # (not {lang} templates) whose tasks must also resolve to a language.
-EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include", "xcsqa-eu", "pawsx-eu", "xnli-eu", "mmmlu-eu"]
+EXPLICIT_MULTILINGUAL_GROUPS = [
+    "mgsm-eu",
+    "include",
+    "xcsqa-eu",
+    "pawsx-eu",
+    "xnli-eu",
+    "mmmlu-eu",
+]
 
 
 def _raw_yaml() -> dict:


### PR DESCRIPTION
## Summary

Adds the **MMMLU** (human-translated MMLU) eval, restricted to the EU-language subset the dataset ships: `de_de`, `es_la`, `fr_fr`, `it_it`, `pt_br`. One of the Evals from https://github.com/OpenEuroLLM/oellm-eval/issues/89

## Changes

- **`task-groups.yaml`** — new `mmmlu-eu` group (5-shot, suite `lm-eval-harness`, `dataset: openai/MMMLU`) mapping each EU locale task to its HF config (`mmmlu_de_de`→`DE_DE`, etc.).
- **`task_groups.py`** — locale→`lang_Scri` aliases (`de_de`→`deu_Latn`, …) so the per-locale tasks resolve to canonical EU language codes and support `mmmlu-eu[deu_Latn]` bracketing.
- **`test_language_groups.py`** — added `mmmlu-eu` to the explicit-multilingual guard list.

## Validation

- Ran `mmmlu_de_de` 5-shot on Qwen3.5-0.8B-Base: **acc = 0.4705 ±0.0092**, well above the 0.25 random-chance floor.