### PR TITLE
feat: evaluate a model's tasks in one lm_eval call instead of one per task

### DIFF
--- a/oellm/main.py
+++ b/oellm/main.py
@@ -111,6 +111,7 @@ def schedule_evals(
     eval_csv_path: str | None = None,
     *,
     max_array_len: int = 128,
+    tasks_per_job: int = 8,
     limit: int | None = None,
     verbose: bool = False,
     download_only: bool = False,
@@ -150,6 +151,11 @@ def schedule_evals(
             Warning: exclusive argument. Cannot specify `models`, `tasks`, `task_groups`, or `n_shot` when `eval_csv_path` is provided.
         max_array_len: The maximum number of jobs to schedule to run concurrently.
             Warning: this is not the number of jobs in the array job. This is determined by the environment variable `QUEUE_LIMIT`.
+        tasks_per_job: The maximum number of lm-eval-harness tasks evaluated by a single
+            `lm_eval` invocation. Tasks that share a model and shot count are evaluated
+            together so the model is loaded once instead of once per task. `lm_eval`
+            fails the whole invocation if one task raises, so this caps how many tasks
+            a single failure takes down; 1 restores one invocation per task.
         limit: If set, limit the number of samples per task (useful for quick testing).
             Passes --limit to lm_eval and --max_samples to lighteval.
         download_only: If True, only download the datasets and models and exit.
@@ -362,8 +368,26 @@ def schedule_evals(
     slurm_logs_dir.mkdir(parents=True, exist_ok=True)
     csv_path = evals_dir / "jobs.csv"
 
-    # Shuffle the dataframe to distribute fast/slow evaluations evenly across array jobs
-    df = df.sample(frac=1, random_state=42).reset_index(drop=True)
+    # Shuffle to distribute fast/slow evaluations evenly across array jobs, but
+    # shuffle *groups* of evaluations that share a model, shot count and suite
+    # rather than individual rows. The sbatch template collapses each such run
+    # of adjacent rows into a single lm_eval invocation, so keeping them
+    # adjacent is what lets the model be loaded once instead of once per task.
+    batch_key = ["model_path", "n_shot", "eval_suite"]
+    group_order = (
+        df[batch_key]
+        .drop_duplicates()
+        .sample(frac=1, random_state=42)
+        .reset_index(drop=True)
+        .reset_index()
+        .rename(columns={"index": "_group_rank"})
+    )
+    df = (
+        df.merge(group_order, on=batch_key, how="left")
+        .sort_values("_group_rank", kind="stable")
+        .drop(columns="_group_rank")
+        .reset_index(drop=True)
+    )
     logging.info(
         "Shuffled evaluation jobs for even load distribution across array workers"
     )
@@ -440,6 +464,7 @@ def schedule_evals(
     sbatch_script = sbatch_template.format(
         csv_path=csv_path,
         max_array_len=max_array_len,
+        tasks_per_job=max(1, tasks_per_job),
         array_limit=actual_array_size - 1,  # Array is 0-indexed
         num_jobs=actual_array_size,  # This is the number of array jobs, not total evals
         total_evals=len(df),  # Pass the total number of evaluations

--- a/oellm/resources/template.sbatch
+++ b/oellm/resources/template.sbatch
@@ -18,6 +18,7 @@ TOTAL_EVALS={total_evals}
 LIMIT="{limit}"
 VENV_PATH="{venv_path}"
 LM_EVAL_INCLUDE_PATH="{lm_eval_include_path}"
+TASKS_PER_JOB={tasks_per_job}
 
 # avoiding crashes due to compute nodes not having access to the internet
 export HF_HOME=$HF_HOME
@@ -62,8 +63,33 @@ fi
 
 # Use `tail` and `head` to slice the CSV file for the tasks assigned to this job.
 # The +1 on START_INDEX accounts for the header row.
+# Collapse adjacent rows that share a model, shot count and lm_eval suite into
+# a single row whose task field is a comma-separated list. lm_eval loads the
+# model once per invocation, so evaluating N tasks in one call replaces N model
+# loads with one. TASKS_PER_JOB caps how many tasks share a call: lm_eval aborts
+# the whole invocation if one task raises, so the cap bounds what a single
+# failure takes down. Suites other than lm_eval pass through one row at a time.
+# The output is tab-separated because a joined task list contains commas.
 tail -n +$((START_INDEX + 1)) "$CSV_PATH" | head -n $((END_INDEX - START_INDEX + 1)) | \
-while IFS=, read -r model_path task_path n_shot eval_suite
+awk -F, -v max_tasks="$TASKS_PER_JOB" -v OFS='\t' '
+    function flush() {{ if (tasks != "") print model, tasks, shots, suite }}
+    {{
+        gsub(/\r/, "")
+        if ($1 == "") next
+        row_suite = ($4 == "" ? "lm_eval" : $4)
+        lowered = tolower(row_suite)
+        batchable = (lowered == "lm_eval" || lowered == "lm-eval" || lowered == "lm-eval-harness")
+        row_key = batchable ? ($1 SUBSEP $3 SUBSEP lowered) : ("unbatched" SUBSEP NR)
+        if (row_key != key || count >= max_tasks) {{
+            flush()
+            key = row_key; model = $1; shots = $3; suite = row_suite; tasks = $2; count = 1
+        }} else {{
+            tasks = tasks "," $2; count++
+        }}
+    }}
+    END {{ flush() }}
+' | \
+while IFS=$'\t' read -r model_path task_path n_shot eval_suite
 do
     # Remove trailing carriage returns if script is edited on Windows
     model_path=$(echo "$model_path" | tr -d '\r')

--- a/tests/test_task_batching.py
+++ b/tests/test_task_batching.py
@@ -1,0 +1,179 @@
+"""Tests for batching lm-eval-harness tasks into one `lm_eval` invocation.
+
+The sbatch template used to run one `lm_eval` per row of ``jobs.csv``, so a
+model evaluated on N tasks was loaded from disk and onto the GPU N times. The
+template now collapses adjacent rows that share a model, shot count and
+lm_eval suite into a single invocation with a comma-separated ``--tasks``
+list, and ``schedule_evals`` orders the CSV so those rows sit together.
+
+Two properties matter and are checked here: the ordering has to keep a group
+adjacent for the collapse to fire at all, and the collapse must not merge rows
+whose ``--num_fewshot`` or suite differ, since both are per-invocation
+arguments rather than per-task ones.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from importlib.resources import files
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from oellm.main import schedule_evals
+
+MODEL_A = "/scratch/checkpoints/iter_0002000"
+MODEL_B = "/scratch/checkpoints/iter_0004000"
+
+SAMPLE_ROWS = [
+    f"{MODEL_A},sib200_eus_Latn,0,lm-eval-harness",
+    f"{MODEL_A},include_base_44_basque,0,lm-eval-harness",
+    f"{MODEL_A},xnli_spa_Latn,0,lm-eval-harness",
+    f"{MODEL_A},belebele_eus_Latn_cf,0,lighteval",
+    f"{MODEL_A},mmlu,5,lm-eval-harness",
+    f"{MODEL_B},sib200_eus_Latn,0,lm-eval-harness",
+]
+
+TEMPLATE_FIELDS = {
+    "csv_path": "/tmp/jobs.csv",
+    "max_array_len": 128,
+    "array_limit": 0,
+    "num_jobs": 1,
+    "total_evals": len(SAMPLE_ROWS),
+    "log_dir": "/tmp/logs",
+    "evals_dir": "/tmp/results",
+    "time_limit": "03:59:00",
+    "slurm_mem": "96G",
+    "limit": "",
+    "venv_path": "",
+    "lm_eval_include_path": "/tmp/tasks",
+    "hf_hub_offline": 1,
+    "additional_model_args": "batch_size=32",
+    "evalchemy_dir": "/opt/evalchemy",
+    "tasks_per_job": 8,
+}
+
+requires_awk = pytest.mark.skipif(shutil.which("awk") is None, reason="awk not available")
+
+
+def _render(**overrides: object) -> str:
+    template = (files("oellm.resources") / "template.sbatch").read_text()
+    return template.format(**{**TEMPLATE_FIELDS, **overrides}).replace("\r\n", "\n")
+
+
+def _awk_program() -> str:
+    """The batching program, taken from the rendered script rather than duplicated."""
+    match = re.search(r"^awk -F, .*?\n(.*?)^' \| \\$", _render(), re.S | re.M)
+    assert match, "batching awk block not found in the rendered template"
+    return match.group(1)
+
+
+def _batches(rows: list[str], tasks_per_job: int = 8) -> list[dict[str, str]]:
+    """Run the template's batching step over CSV rows, as the job would."""
+    result = subprocess.run(
+        [
+            "awk",
+            "-F,",
+            "-v",
+            f"max_tasks={tasks_per_job}",
+            "-v",
+            "OFS=\t",
+            _awk_program(),
+        ],
+        input="\n".join(rows) + "\n",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    batches = []
+    for line in result.stdout.strip().split("\n"):
+        model, tasks, n_shot, suite = line.split("\t")
+        batches.append({"model": model, "tasks": tasks, "n_shot": n_shot, "suite": suite})
+    return batches
+
+
+@requires_awk
+def test_tasks_sharing_a_model_become_one_invocation() -> None:
+    batches = _batches(SAMPLE_ROWS)
+
+    lm_eval_zero_shot = [
+        b
+        for b in batches
+        if b["model"] == MODEL_A
+        and b["suite"] == "lm-eval-harness"
+        and b["n_shot"] == "0"
+    ]
+    assert len(lm_eval_zero_shot) == 1
+    assert (
+        lm_eval_zero_shot[0]["tasks"]
+        == "sib200_eus_Latn,include_base_44_basque,xnli_spa_Latn"
+    )
+
+
+@requires_awk
+def test_no_evaluation_is_lost_or_duplicated() -> None:
+    batches = _batches(SAMPLE_ROWS)
+
+    scheduled = [
+        (b["model"], task, b["n_shot"]) for b in batches for task in b["tasks"].split(",")
+    ]
+    expected = [
+        (row.split(",")[0], row.split(",")[1], row.split(",")[2]) for row in SAMPLE_ROWS
+    ]
+
+    assert sorted(scheduled) == sorted(expected)
+
+
+@requires_awk
+def test_shot_count_suite_and_model_are_batch_boundaries() -> None:
+    """--num_fewshot and the suite are per-invocation, so they cannot be merged."""
+    batches = _batches(SAMPLE_ROWS)
+
+    by_key = {(b["model"], b["n_shot"], b["suite"]): b["tasks"] for b in batches}
+    assert by_key[(MODEL_A, "5", "lm-eval-harness")] == "mmlu"
+    assert by_key[(MODEL_A, "0", "lighteval")] == "belebele_eus_Latn_cf"
+    assert by_key[(MODEL_B, "0", "lm-eval-harness")] == "sib200_eus_Latn"
+
+
+@requires_awk
+def test_cap_bounds_the_batch_size() -> None:
+    for tasks_per_job in (1, 2, 3):
+        batches = _batches(SAMPLE_ROWS, tasks_per_job=tasks_per_job)
+        assert all(len(b["tasks"].split(",")) <= tasks_per_job for b in batches)
+
+
+@requires_awk
+def test_cap_of_one_keeps_an_invocation_per_task() -> None:
+    """The escape hatch: --tasks_per_job 1 is the pre-batching behaviour."""
+    batches = _batches(SAMPLE_ROWS, tasks_per_job=1)
+
+    assert len(batches) == len(SAMPLE_ROWS)
+
+
+def test_scheduled_csv_keeps_a_batch_adjacent(tmp_path: Path) -> None:
+    """The collapse only fires on adjacent rows, so ordering has to preserve groups."""
+    with (
+        patch("oellm.main._load_cluster_env"),
+        patch("oellm.main._num_jobs_in_queue", return_value=0),
+        patch.dict(os.environ, {"EVAL_OUTPUT_DIR": str(tmp_path)}),
+    ):
+        schedule_evals(
+            models="EleutherAI/pythia-70m,EleutherAI/pythia-160m",
+            task_groups="sib200-eu",
+            n_shot=0,
+            skip_checks=True,
+            venv_path=str(Path(sys.prefix)),
+            dry_run=True,
+        )
+
+    jobs_csv = next(iter(tmp_path.glob("**/jobs.csv")))
+    df = pd.read_csv(jobs_csv)
+    assert df["model_path"].nunique() > 1
+
+    keys = list(zip(df["model_path"], df["n_shot"], df["eval_suite"], strict=True))
+    runs = [key for index, key in enumerate(keys) if index == 0 or key != keys[index - 1]]
+    assert len(runs) == len(set(runs)), "rows sharing a batch key are not adjacent"


### PR DESCRIPTION
Closes #95.

Every row of `jobs.csv` becomes its own `lm_eval` invocation, and `lm_eval` loads the model from disk and onto the GPU once per invocation. A checkpoint evaluated on N tasks pays N model loads to run the same weights.

The reporter's own listing shows it:

```
model_path,task_path,n_shot,eval_suite
.../hf_checkpoints/iter_0002000,sib200_eus_Latn,0,lm-eval-harness
.../hf_checkpoints/iter_0002000,belebele_eus_Latn_cf,0,lighteval
.../hf_checkpoints/iter_0002000,include_base_44_basque,0,lm-eval-harness
```

Two of those three rows are the same model at the same shot count on the same suite, so they can share one call.

### The change

Adjacent rows sharing a model, a shot count and the lm_eval suite are collapsed into one invocation with a comma-separated `--tasks` list. The collapse happens in the sbatch template, so `jobs.csv` still holds one row per evaluation and `--check` accounting is untouched. The join produces commas, so the collapsed stream is tab-separated and the read loop switches to a tab `IFS`; that stream is internal to the job script and no file format changes.

The shuffle that spreads fast and slow evaluations across array workers now shuffles those groups instead of individual rows, since the collapse only fires on rows that end up adjacent.

`--num_fewshot` and the suite are per-invocation arguments rather than per-task ones, so both are batch boundaries alongside the model. Suites other than lm_eval keep running one row at a time.

### The failure trade-off

`lm_eval` fails the whole invocation when one task raises, so batching widens the blast radius of a single bad task. `tasks_per_job` bounds it: it defaults to 8, and `--tasks_per_job 1` restores exactly one invocation per task, which is today's behaviour. I picked a cap rather than an on/off flag so the trade-off is tunable instead of binary, but I am happy to change the default or make it opt-in.

### It needs #109 first

A batched run writes one result JSON containing several tasks, and `collect_results` currently keeps at most one entry per JSON. I ran a three-task batch through the collector both ways:

| | collected | `--check` reports missing |
|---|---|---|
| this branch on `main` | 1 of 3 | the other 2 |
| this branch with #109 | 3 of 3 | nothing |

So merging this on its own turns a slow-but-correct sweep into a fast one that silently drops results and then asks the cluster to redo them. #109 fixes that path and carries a regression test for the multi-task file. Worth sequencing them, or taking them together.

### Known limit

Array elements get a contiguous slice of the CSV, so a group that spans a slice boundary is evaluated as two batches instead of one. That costs one extra model load per boundary, at most one per array element, and needs no special handling to stay correct.

### On the queue capacity half of the issue

Worth noting for the reporter separately: `_num_jobs_in_queue` counts with `squeue -r`, which lists each array element as its own line, so `QUEUE_LIMIT` is consumed per element rather than per array job. Running `oellm-eval schedule` once per checkpoint therefore multiplies arrays against that budget. `_expand_local_model_paths` already walks a directory into every checkpoint under it, so pointing `--models` at the parent once packs the whole sweep into a single array sized to the remaining capacity. That does not need a code change, but it is not obvious from the docs.

### Tests

`tests/test_task_batching.py` runs the template's own batching step, extracted from the rendered script rather than duplicated, over sample CSV rows:

* tasks sharing a model and shot count become one invocation
* no evaluation is lost or duplicated by the collapse
* model, shot count and suite are all batch boundaries
* the cap bounds batch size, and a cap of 1 is the pre-batching behaviour
* the scheduled `jobs.csv` keeps a batch adjacent, checked across two models

All six fail on `main` and pass with this change. Merging this branch with #88 and with #109 is clean; it does conflict with the #107 draft, which restructures the same read loop into a process substitution, and I am happy to rebase onto whichever lands first. The rest of the suite passes (108 tests, excluding the ones that reach out to HuggingFace) and `ruff check` and `ruff format` are clean.
