### PR TITLE
Scope oellm-multilingual to the OpenEuroLLM target languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ Available task groups:
 - `include` - INCLUDE benchmarks
 
 Super groups combine multiple task groups:
-- `oellm-multilingual` - All multilingual benchmarks combined
+- `oellm-multilingual` - Every multilingual benchmark, scoped to the 36
+  prioritised OpenEuroLLM target languages (the 24 official EU languages,
+  Catalan/Basque/Galician, candidate-member languages, Icelandic/Norwegian).
+  Off-list languages some benchmarks ship (Russian, Hebrew, Armenian,
+  Azerbaijani, Belarusian) are not scheduled; use `all` to reach them.
 
 ```bash
 # Use a task group
@@ -79,12 +83,14 @@ Scope a task group (or super group) to one or more languages by attaching a
 # The applicable subset of the multilingual super group for one language —
 # the simplest way to evaluate a monolingual model on its language across
 # every multilingual benchmark (FLORES, Belebele, Global-MMLU, INCLUDE, MGSM,
-# …), spanning both lm-eval-harness and lighteval.
+# SIB-200, PolyMath, …), spanning both lm-eval-harness and lighteval. The
+# bracket narrows within the group's target-language scope; it cannot widen it.
 oellm-eval schedule --models "my-model" --task_groups "oellm-multilingual[deu_Latn]"
 
 # Every benchmark in the registry for one language. `all` is an auto-generated
-# super group (always spans every task group, no hand-maintenance) — use it for
-# the complete per-language set rather than the curated `oellm-multilingual`.
+# super group (always spans every task group, no hand-maintenance) and carries
+# no language scope — use it for the complete per-language set, or to reach a
+# language `oellm-multilingual` deliberately excludes.
 oellm-eval schedule --models "my-model" --task_groups "all[deu_Latn]"
 
 # A single benchmark, scoped to German.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -54,6 +54,7 @@ oellm-eval schedule --models "model-name" --task_groups "my-benchmark"
 | `dataset` | Yes | group or task | HuggingFace dataset repo ID (required for pre-download and testing) |
 | `task` | Yes | task | Task name as recognized by the evaluation suite |
 | `subset` | No | task | HuggingFace dataset config/subset name |
+| `languages` | No | super group | Canonical `lang_Scri` codes the super group is scoped to (see below) |
 
 ## Language filtering (`group[lang]` brackets)
 
@@ -79,8 +80,9 @@ input — they are rejected with an error naming the canonical code. (The foldin
 described below applies only to the benchmarks' own internal spellings when
 deriving a task's language, not to what you type in the bracket.)
 
-Languages are **derived in code** — there is no `languages` field to set in the
-YAML. A task resolves to a canonical [`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag)
+Languages are **derived in code**: no YAML field tags a *task* with a language.
+(A super group's `languages` key, below, only selects among the codes tasks
+already resolve to.) A task resolves to a canonical [`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag)
 code (e.g. `deu_Latn`) from, in order:
 
 1. **`flores200:src-tgt` task names** → the non-English side(s) of the pair.
@@ -105,6 +107,39 @@ tasks, since each task carries its own resolved suite. Unknown codes error; a
 bracket that matches no task in its group errors; when a bracket lists several
 languages and only some are present, the matches are kept and the rest warned
 about (some languages simply lack certain benchmarks).
+
+### Declaring a super group's language scope
+
+A super group may carry its own `languages:` list, so callers get the right
+languages without spelling them out in a bracket every time:
+
+```yaml
+super_groups:
+  oellm-multilingual:
+    description: "..."
+    languages: [bul_Cyrl, ces_Latn, deu_Latn]   # canonical codes
+    task_groups:
+      - task: sib200-eu
+      - task: flores-200-eu-to-eng
+```
+
+```bash
+# Already scoped -- no bracket needed
+oellm-eval schedule --models "m" --task_groups "oellm-multilingual"
+```
+
+The declared codes are validated when the registry loads, so a typo or a
+language no benchmark covers fails immediately rather than silently narrowing
+the group to nothing. A caller's bracket **narrows within** the declared scope:
+`oellm-multilingual[deu_Latn]` gives German only, while a code outside the scope
+errors instead of widening it — reach past it with `all[<code>]`, which is
+unscoped. Plain task groups take no `languages` key, and a super group without
+one behaves exactly as before.
+
+Note that a declared scope drops tasks that resolve to *no* language, since a
+language filter cannot keep them. Aggregate multi-language tasks such as
+`xwinograd` or `xstorycloze` therefore cannot live in a scoped super group;
+request their group (`generic-multilingual`) directly.
 
 ## Important: Dataset Requirement
 

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -959,14 +959,76 @@ task_groups:
 
 super_groups:
   oellm-multilingual:
-    description: "Combined Belebele EU set plus multilingual benchmarks"
+    description: >-
+      Every multilingual benchmark in the OpenEuroLLM evaluation suite, scoped
+      to the 36 prioritised target languages: the 24 official EU languages,
+      Catalan/Basque/Galician, the candidate-member languages, and
+      Icelandic/Norwegian. Off-list languages that some benchmarks ship
+      (Russian, Hebrew, Armenian, Azerbaijani, Belarusian) are not scheduled.
+    # 37 codes for 36 languages -- Norwegian has two written standards.
+    # Spellings are this registry's canonical ones: Latvian is lvs_Latn,
+    # Albanian als_Latn, Serbian srp_Cyrl (no benchmark ships srp_Latn).
+    languages:
+      # 24 official EU languages
+      - bul_Cyrl
+      - ces_Latn
+      - dan_Latn
+      - deu_Latn
+      - ell_Grek
+      - eng_Latn
+      - est_Latn
+      - fin_Latn
+      - fra_Latn
+      - gle_Latn
+      - hrv_Latn
+      - hun_Latn
+      - ita_Latn
+      - lit_Latn
+      - lvs_Latn
+      - mlt_Latn
+      - nld_Latn
+      - pol_Latn
+      - por_Latn
+      - ron_Latn
+      - slk_Latn
+      - slv_Latn
+      - spa_Latn
+      - swe_Latn
+      # co-official languages of member states
+      - cat_Latn
+      - eus_Latn
+      - glg_Latn
+      # candidate members
+      - als_Latn
+      - bos_Latn
+      - kat_Geor
+      - mkd_Cyrl
+      - srp_Cyrl
+      - tur_Latn
+      - ukr_Cyrl
+      # closely associated Scandinavian
+      - isl_Latn
+      - nno_Latn
+      - nob_Latn
     task_groups:
-      - task: flores-200-eu-to-eng
-      - task: flores-200-eng-to-eu
+      - task: arc-challenge-mt-eu
       - task: belebele-eu-5-shot
+      - task: flores-200-eng-to-eu
+      - task: flores-200-eu-to-eng
+      - task: global-mgsm-eu
       - task: global-mmlu-eu
-      - task: mgsm-eu
-      - task: generic-multilingual
+      - task: global-piqa-eu-completions
+      - task: global-piqa-eu-prompted
+      - task: hellaswag-eu
       - task: include
+      - task: mgsm-eu
       - task: multiblimp-eu
+      - task: opensubtitles-eu-en-xx
+      - task: opensubtitles-eu-xx-en
+      - task: polymath-eu-high
+      - task: polymath-eu-low
+      - task: polymath-eu-medium
+      - task: polymath-eu-top
+      - task: sib200-eu
       - task: xcopa-eu
+      - task: xcsqa-eu

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -247,9 +247,19 @@ class TaskGroup:
 
 @dataclass
 class TaskSuperGroup:
+    """A named collection of task groups.
+
+    ``languages`` is an optional declared scope: when set, the super_group
+    resolves only to the tasks in its groups that belong to those languages,
+    without the caller having to spell them out in a ``[...]`` bracket. A
+    caller-supplied bracket narrows within the declared scope; it cannot widen
+    past it.
+    """
+
     name: str
     task_groups: list[TaskGroup]
     description: str
+    languages: list[str] | None = None
 
     def __post_init__(self):
         resolved_groups = []
@@ -274,10 +284,12 @@ class TaskSuperGroup:
                 )
             task_groups.append(available_task_groups[group_name])
 
+        languages = data.get("languages")
         return cls(
             name=name,
             task_groups=task_groups,
             description=data["description"],
+            languages=list(languages) if languages else None,
         )
 
 
@@ -350,6 +362,21 @@ def _parse_task_groups(
         super_groups[super_group_name] = TaskSuperGroup.from_dict(
             super_group_name, super_group_data, task_groups
         )
+
+    # A declared ``languages`` scope is checked against the codes tasks actually
+    # resolve to, so a typo or a language no benchmark covers fails at load time
+    # rather than silently narrowing the super_group to nothing.
+    known_codes = _language_codes_from_groups(task_groups)
+    for super_group in super_groups.values():
+        if not super_group.languages:
+            continue
+        unknown = [c for c in super_group.languages if c not in known_codes]
+        if unknown:
+            raise ValueError(
+                f"Super group '{super_group.name}' declares unknown language "
+                f"code(s): {', '.join(sorted(unknown))}. Use the precise "
+                f"lang_Scri form; valid codes: {', '.join(sorted(known_codes))}"
+            )
 
     # Reserved super_group spanning every task group, generated from the
     # registry so it never needs hand-maintaining as groups are added. Pair it
@@ -502,6 +529,10 @@ def _select_tasks(group_names: Iterable[str]) -> list[tuple[str, _Task]]:
     A per-group ``[...]`` language bracket keeps only the tasks in that group
     (or super_group) that resolve to one of the bracketed languages, and
     hard-errors if it matches nothing in that group.
+
+    A super_group that declares a ``languages`` scope is filtered to it even
+    without a bracket; a bracket then narrows within that scope, and asking for
+    a language outside it raises rather than widening the group.
     """
     specs = _resolve_group_specs(group_names)
 
@@ -513,6 +544,23 @@ def _select_tasks(group_names: Iterable[str]) -> list[tuple[str, _Task]]:
     selected: list[tuple[str, _Task]] = []
     seen: set[tuple[str, str]] = set()
     for name, filt in specs:
+        # A super_group may declare its own language scope. A caller bracket
+        # narrows within it; on its own the declaration acts as the filter.
+        declared = getattr(parsed[name], "languages", None)
+        bracketed = filt is not None
+        if declared:
+            if filt is None:
+                filt = list(declared)
+            else:
+                scope = set(declared)
+                narrowed = [lang for lang in filt if lang in scope]
+                if not narrowed:
+                    raise ValueError(
+                        f"Language(s) {{{', '.join(filt)}}} are outside the scope "
+                        f"of super group '{name}' ({', '.join(sorted(declared))})."
+                    )
+                filt = narrowed
+
         group_pairs = list(_iter_group_tasks({name: parsed[name]}))
         if filt is None:
             kept = group_pairs
@@ -525,7 +573,9 @@ def _select_tasks(group_names: Iterable[str]) -> list[tuple[str, _Task]]:
                 )
             matched = {lang for _s, t in kept for lang in t.languages if lang in filt}
             unmatched = [lang for lang in filt if lang not in matched]
-            if unmatched:
+            # A declared scope spans many benchmarks, and no single benchmark
+            # covers all of it -- only an explicit bracket is worth warning about.
+            if unmatched and bracketed:
                 logging.warning(
                     "No tasks matched language(s) %s in group '%s'; kept %s.",
                     ", ".join(unmatched),

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -17,6 +17,7 @@ from oellm.task_groups import (
     _expand_task_groups,
     _load_task_groups_data,
     _resolve_task_languages,
+    _select_tasks,
     get_all_language_codes,
     split_group_tokens,
 )
@@ -119,13 +120,26 @@ def test_super_group_bracket_resolves_language_subset():
     jobs = _expand_task_groups(["oellm-multilingual[deu_Latn]"])
     tasks = {j.task for j in jobs}
     assert tasks == {
+        "arc_challenge_mt_de",
         "belebele_deu_Latn",
         "flores200:deu_Latn-eng_Latn",
         "flores200:eng_Latn-deu_Latn",
+        "global_mgsm_de",
         "global_mmlu_full_de",
+        "global_piqa_completions_deu_latn",
+        "global_piqa_prompted_deu_latn",
+        "hellaswag_de",
         "include_base_44_german",
         "mgsm_native_cot_de",
         "multiblimp_deu",
+        "opensubtitles_multi40_de_to_en",
+        "opensubtitles_multi40_en_to_de",
+        "polymath_de_high",
+        "polymath_de_low",
+        "polymath_de_medium",
+        "polymath_de_top",
+        "sib200_deu_Latn",
+        "xcsqa_deu_Latn",
     }
     suites = {j.suite for j in jobs}
     assert "lm-eval-harness" in suites
@@ -208,3 +222,89 @@ def test_templated_tasks_all_resolve_to_a_language():
                 f"{name}: task {task['task']} (subset={task.get('subset')}) "
                 "did not resolve to a language"
             )
+
+
+# --- declared super_group language scope -------------------------------------
+# A super_group may carry a `languages:` list in the YAML, which scopes it
+# without the caller spelling the codes out in a bracket.
+
+EU_TARGETS = "oellm-multilingual"
+# Languages some benchmarks ship that are not OpenEuroLLM targets.
+OFF_TARGET_CODES = ["rus_Cyrl", "heb_Hebr", "hye_Armn", "aze_Latn", "bel_Cyrl"]
+
+
+def _declared_scope(name: str) -> list[str]:
+    return _raw_yaml()["super_groups"][name]["languages"]
+
+
+def test_declared_scope_codes_are_valid():
+    """Every declared code must be one a task actually resolves to, or the
+    super_group would silently narrow to nothing."""
+    valid = set(get_all_language_codes())
+    assert set(_declared_scope(EU_TARGETS)) <= valid
+
+
+def test_declared_scope_applies_without_a_bracket():
+    """`oellm-eu-targets` alone resolves to exactly its declared languages."""
+    _suite_and_tasks = _select_tasks([EU_TARGETS])
+    reached = {lang for _s, t in _suite_and_tasks for lang in t.languages}
+    assert reached == set(_declared_scope(EU_TARGETS))
+
+
+def test_declared_scope_excludes_off_target_languages():
+    tasks = {j.task for j in _expand_task_groups([EU_TARGETS])}
+    assert tasks
+    for absent in [
+        "global_mmlu_full_ru",
+        "global_mmlu_full_he",
+        "include_base_44_russian",
+    ]:
+        assert absent not in tasks
+
+
+def test_declared_scope_narrows_with_a_bracket():
+    scoped = {j.task for j in _expand_task_groups([f"{EU_TARGETS}[deu_Latn]"])}
+    full = {j.task for j in _expand_task_groups([EU_TARGETS])}
+    assert scoped
+    assert scoped < full
+
+
+@pytest.mark.parametrize("code", OFF_TARGET_CODES)
+def test_declared_scope_cannot_be_widened_by_a_bracket(code):
+    """A bracket narrows within the declared scope; it cannot reach past it."""
+    with pytest.raises(ValueError) as excinfo:
+        _expand_task_groups([f"{EU_TARGETS}[{code}]"])
+    assert "outside the scope" in str(excinfo.value)
+
+
+def test_declared_scope_rejects_unknown_codes_at_load_time(monkeypatch):
+    """A typo'd or uncovered code fails when the registry loads, not silently."""
+    from oellm import task_groups as tg
+
+    data = _load_task_groups_data()
+    data["super_groups"]["_bad"] = {
+        "description": "typo'd scope",
+        "languages": ["deu_Latn", "nope_Xxxx"],
+        "task_groups": [{"task": "sib200-eu"}],
+    }
+    monkeypatch.setattr(tg, "_load_task_groups_data", lambda: data)
+    with pytest.raises(ValueError) as excinfo:
+        tg._parse_task_groups(["_bad"])
+    assert "nope_Xxxx" in str(excinfo.value)
+
+
+def test_super_group_without_a_declared_scope_is_unaffected():
+    """The synthetic `all` super_group declares no scope, so it still reaches
+    languages outside any declared list."""
+    reached = {lang for _s, t in _select_tasks(["all"]) for lang in t.languages}
+    assert set(OFF_TARGET_CODES) <= reached
+    assert _expand_task_groups(["all[rus_Cyrl]"])
+
+
+def test_declared_scope_covers_every_listed_group():
+    """Each group listed in the super_group must contribute at least one task
+    under the declared scope -- an entry that contributes nothing is a mistake."""
+    listed = [g["task"] for g in _raw_yaml()["super_groups"][EU_TARGETS]["task_groups"]]
+    scope = ",".join(_declared_scope(EU_TARGETS))
+    for group_name in listed:
+        assert _expand_task_groups([f"{group_name}[{scope}]"]), group_name


### PR DESCRIPTION
## What changed

A super_group may now declare a `languages:` scope in `task-groups.yaml`, and `oellm-multilingual` uses it: every multilingual benchmark, restricted to the 36 target languages.

```bash
# unchanged command, now the whole suite and only target languages
oellm-eval schedule --models "m" --task_groups "oellm-multilingual"
```

|  | before | after |
|---|---:|---:|
| task groups | 9 | 21 |
| eval units | 179 | 401 |
| languages | 41 (5 off-list) | 36 (37 codes — Norwegian has two written standards) |

Scope semantics:

- **No bracket** → the declared scope is the filter.
- **A bracket narrows within it** — `oellm-multilingual[deu_Latn]` is German only.
- **A bracket cannot widen it** — `oellm-multilingual[rus_Cyrl]` raises. Use `all[rus_Cyrl]`, which carries no scope.
- **Codes are validated when the registry loads**, against the codes tasks actually resolve to, so a typo or an uncovered language fails immediately instead of quietly narrowing the group to nothing.
- Plain task groups take no `languages` key; a super_group without one behaves exactly as before.

The "language matched nothing" warning now fires only for an explicit bracket. A 37-code scope legitimately misses languages in most individual benchmarks, so it would otherwise warn on every group in the super_group.

Languages are still **derived in code** — nothing tags a task with a language in YAML. `languages:` only selects among codes tasks already resolve to.

### Language list

24 official EU + Catalan/Basque/Galician + candidate members (Albanian, Bosnian, Georgian, Macedonian, Serbian, Turkish, Ukrainian) + Icelandic/Norwegian. Registry spellings: Latvian is `lvs_Latn`, Albanian `als_Latn`, Serbian `srp_Cyrl` (no benchmark ships `srp_Latn`), Norwegian both `nob_Latn` and `nno_Latn`.

## Breaking changes

- **`generic-multilingual` leaves the super_group.** `xwinograd`, `xcopa` and `xstorycloze` are aggregate tasks that resolve to no single language, so a language filter cannot keep them. Request `generic-multilingual` directly to run them. This is the one capability the redefinition removes.
- Anyone relying on `oellm-multilingual` to reach Russian/Hebrew/Armenian/Azerbaijani/Belarusian must switch to `all[<code>]` or name the group directly.
- The group now schedules ~2.2x the eval units. It is the full suite, so budget accordingly, or narrow with a bracket.

## Validation

- `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/test_datasets.py` → 122 passed. (`tests/test_datasets.py` needs Hub access; it fails identically on `main` in my environment.)
- `ruff format --check`, `ruff check` clean. `ty check` reports only diagnostics that pre-exist on `main` (`oellm/utils.py`, polymath utils, stdlib).
- Expansion checked against the frozen 15-benchmark campaign behind the multilingual-eval paper: the new group is a strict superset of all 377 target-language eval units that campaign ran. The 24 extra units are FLORES-200 pairs for target languages the frozen campaign happened not to include (Catalan, Basque, Galician, Icelandic, Norwegian, Georgian, Macedonian, Albanian, Bosnian, Serbian, Turkish, Ukrainian).
- Verified no off-list language leaks into the expansion, and that a bracket cannot widen the scope.
