### PR TITLE
Add multilingual-oellm-eu super group

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ Available task groups:
 
 Super groups combine multiple task groups:
 - `oellm-multilingual` - All multilingual benchmarks combined
+- `multilingual-oellm-eu` - Every multilingual benchmark, in the 36 prioritised
+  OpenEuroLLM target languages (24 official EU languages,
+  Catalan/Basque/Galician, candidate members, Icelandic/Norwegian). 401 eval
+  units across all 15 multilingual benchmarks and both eval suites:
+
+  ```bash
+  oellm-eval schedule --models "my-model" --task_groups "multilingual-oellm-eu"
+  ```
+
+  Russian, Hebrew, Armenian, Azerbaijani and Belarusian were dropped from
+  `global-mmlu-eu` and `include` to make this possible, so they are no longer
+  reachable through any task group.
 
 ```bash
 # Use a task group

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -583,7 +583,7 @@ task_groups:
     suite: lm-eval-harness
     n_shots: [5]
     dataset: CohereForAI/Global-MMLU
-    valid_langs: [cs, de, el, en, es, fr, it, lt, nl, pl, pt, ro, ru, sr, sv, tr, uk, he]
+    valid_langs: [cs, de, el, en, es, fr, it, lt, nl, pl, pt, ro, sr, sv, tr, uk]
     tasks:
       - task: "global_mmlu_full_{lang}"
         subset: "{lang}"
@@ -658,14 +658,8 @@ task_groups:
     tasks:
       - task: include_base_44_albanian
         subset: Albanian
-      - task: include_base_44_armenian
-        subset: Armenian
-      - task: include_base_44_azerbaijani
-        subset: Azerbaijani
       - task: include_base_44_basque
         subset: Basque
-      - task: include_base_44_belarusian
-        subset: Belarusian
       - task: include_base_44_bulgarian
         subset: Bulgarian
       - task: include_base_44_croatian
@@ -696,8 +690,6 @@ task_groups:
         subset: Polish
       - task: include_base_44_portuguese
         subset: Portuguese
-      - task: include_base_44_russian
-        subset: Russian
       - task: include_base_44_serbian
         subset: Serbian
       - task: include_base_44_spanish
@@ -970,3 +962,32 @@ super_groups:
       - task: include
       - task: multiblimp-eu
       - task: xcopa-eu
+
+  multilingual-oellm-eu:
+    description: >-
+      Every multilingual benchmark in the OpenEuroLLM evaluation suite, in the
+      36 prioritised target languages: the 24 official EU languages,
+      Catalan/Basque/Galician, the candidate-member languages, and
+      Icelandic/Norwegian.
+    task_groups:
+      - task: arc-challenge-mt-eu
+      - task: belebele-eu-5-shot
+      - task: flores-200-eng-to-eu
+      - task: flores-200-eu-to-eng
+      - task: global-mgsm-eu
+      - task: global-mmlu-eu
+      - task: global-piqa-eu-completions
+      - task: global-piqa-eu-prompted
+      - task: hellaswag-eu
+      - task: include
+      - task: mgsm-eu
+      - task: multiblimp-eu
+      - task: opensubtitles-eu-en-xx
+      - task: opensubtitles-eu-xx-en
+      - task: polymath-eu-high
+      - task: polymath-eu-low
+      - task: polymath-eu-medium
+      - task: polymath-eu-top
+      - task: sib200-eu
+      - task: xcopa-eu
+      - task: xcsqa-eu

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -17,6 +17,7 @@ from oellm.task_groups import (
     _expand_task_groups,
     _load_task_groups_data,
     _resolve_task_languages,
+    _select_tasks,
     get_all_language_codes,
     split_group_tokens,
 )
@@ -208,3 +209,50 @@ def test_templated_tasks_all_resolve_to_a_language():
                 f"{name}: task {task['task']} (subset={task.get('subset')}) "
                 "did not resolve to a language"
             )
+
+
+# --- multilingual-oellm-eu --------------------------------------------------------
+# A super_group over the whole multilingual suite. It needs no language bracket
+# because the member groups themselves no longer carry non-target languages.
+
+# Dropped from global-mmlu-eu (ru, he) and include (hy, az, be, ru).
+OFF_TARGET_CODES = ["rus_Cyrl", "heb_Hebr", "hye_Armn", "aze_Latn", "bel_Cyrl"]
+
+
+def test_off_target_languages_are_gone_from_the_registry():
+    """No task group ships them any more, so no group can schedule them."""
+    assert not set(get_all_language_codes()) & set(OFF_TARGET_CODES)
+
+
+def test_multilingual_oellm_eu_reaches_no_off_target_language():
+    reached = {
+        lang for _s, t in _select_tasks(["multilingual-oellm-eu"]) for lang in t.languages
+    }
+    assert reached
+    assert not reached & set(OFF_TARGET_CODES)
+
+
+def test_multilingual_oellm_eu_spans_both_eval_suites():
+    suites = {j.suite for j in _expand_task_groups(["multilingual-oellm-eu"])}
+    assert suites == {"lm-eval-harness", "lighteval"}
+
+
+def test_multilingual_oellm_eu_every_listed_group_contributes():
+    """A listed group that resolves to nothing is a typo, not a no-op."""
+    listed = [
+        g["task"]
+        for g in _raw_yaml()["super_groups"]["multilingual-oellm-eu"]["task_groups"]
+    ]
+    assert len(listed) == len(set(listed))
+    for group_name in listed:
+        assert _expand_task_groups([group_name]), group_name
+
+
+def test_multilingual_oellm_eu_spans_more_than_the_curated_multilingual_group():
+    """It is the whole suite: everything oellm-multilingual reaches, plus the
+    benchmarks that group never covered (SIB-200, PolyMath, global PIQA, ...)."""
+    targets = {j.task for j in _expand_task_groups(["multilingual-oellm-eu"])}
+    curated = {j.task for j in _expand_task_groups(["oellm-multilingual"])}
+    assert curated - {"xwinograd", "xcopa", "xstorycloze"} < targets
+    for extra in ["sib200_deu_Latn", "polymath_de_top", "xcsqa_deu_Latn"]:
+        assert extra in targets

--- a/tests/test_task_groups.py
+++ b/tests/test_task_groups.py
@@ -164,9 +164,13 @@ class TestExpandTaskGroupsWithTemplates:
         results = _expand_task_groups(["flores-200-eu-to-eng"])
         assert len(results) == 35
 
-    def test_global_mmlu_expands_to_18_tasks(self):
+    def test_global_mmlu_expands_to_16_tasks(self):
+        """16, not 18: Russian and Hebrew are not OpenEuroLLM target languages."""
         results = _expand_task_groups(["global-mmlu-eu"])
-        assert len(results) == 18
+        assert len(results) == 16
+        task_names = {r.task for r in results}
+        assert "global_mmlu_full_ru" not in task_names
+        assert "global_mmlu_full_he" not in task_names
 
     def test_global_piqa_completions_expands_to_32_tasks(self):
         results = _expand_task_groups(["global-piqa-eu-completions"])


### PR DESCRIPTION
Adds `multilingual-oellm-eu`: all 15 multilingual benchmarks (21 task groups, 401 eval units, both eval suites) in the 36 OpenEuroLLM target languages. `oellm-multilingual` covers only 9 of those benchmarks.

```bash
oellm-eval schedule --models "my-model" --task_groups "multilingual-oellm-eu"
```