### PR TITLE
Fix lighteval running on CPU on LUMI (#96)

### DIFF
--- a/containers/lumi.def
+++ b/containers/lumi.def
@@ -22,10 +22,28 @@ From: rocm/pytorch:rocm6.4.1_ubuntu24.04_py3.12_pytorch_release_2.7.1
         accelerate \
         nltk
 
-    # lighteval as isolated tool (avoids dependency conflicts)
+    # lighteval as isolated tool (avoids dependency conflicts).
+    #
+    # --torch-backend rocm6.4 is REQUIRED on LUMI. `uv tool install` builds an
+    # isolated venv and re-resolves every dependency from PyPI, including torch --
+    # so it pulls the default CUDA wheel (torch==2.10.0+cu128) even though the base
+    # image ships ROCm torch. On MI250X that wheel reports device_count() == 0,
+    # accelerate then selects cpu, and lighteval logs "putting model on device cpu"
+    # and runs on CPU until it hits the walltime. No *_VISIBLE_DEVICES setting can
+    # help: the wheel has no HIP support compiled in. See issue #96.
+    # lm-eval is unaffected because it is installed with `uv pip install --system`
+    # above, reusing the base image's ROCm torch.
+    #
+    # xxhash<4 is also required: 4.0 dropped implicit str encoding, and lighteval
+    # hashes doc.query directly (logging/info_loggers.py), so a fresh resolve picks
+    # up xxhash 4.0.1 and every run dies with "TypeError: Strings must be encoded
+    # before hashing" right after COMPUTING METRICS. Independent of lighteval's
+    # version -- v0.13.0 and main both hit it.
     uv tool install --python 3.12 \
+        --torch-backend rocm6.4 \
         --with "langcodes[data]" \
         --with "pillow" \
+        --with "xxhash<4" \
         "lighteval[multilingual] @ git+https://github.com/huggingface/lighteval.git"
 
     # Pre-load lighteval registry to trigger tinyBenchmarks data download at build time


### PR DESCRIPTION
Closes #96.

## Root cause

`containers/lumi.def` installs the two harnesses differently:

```bash
uv pip install --system --break-system-packages lm-eval ...   # base image Python (ROCm torch)
uv tool install --python 3.12 "lighteval[multilingual] @ git+..."  # isolated venv
```

`uv tool install` builds an isolated venv and **re-resolves every dependency from PyPI, torch included**. It therefore pulls the default **CUDA** wheel even though the base image is `rocm/pytorch` and already ships ROCm torch. Measured inside the current `eval_env-lumi.sif` on an MI250X:

| environment | torch | `version.hip` | `device_count()` |
|---|---|---|---|
| `/opt/uv-tools/lighteval` ← **lighteval runs here** | `2.10.0+cu128` | `None` | **0** |
| `/opt/conda/envs/py_3.12` ← lm-eval runs here | `2.7.1+rocm6.4.1` | `6.4.43483` | 1 |

With 0 visible GPUs, accelerate selects `cpu`:

```
Setting model parallel to False since the number of local processes is 1 and the number of GPUs is 0
Using Data Parallelism, putting model on device cpu   (transformers_model.py:222)
```

and the job grinds on CPU until the walltime kills it.

**This is also why the `HIP_VISIBLE_DEVICES` workaround in the issue doesn't help.** A `+cu128` wheel has no HIP support compiled in, so no `*_VISIBLE_DEVICES` setting can expose an AMD GPU to it — those variables select *among* visible devices, they can't add a backend. lm-eval is unaffected because it goes in via `uv pip install --system`, reusing the base image's ROCm torch.

## The fix

`--torch-backend rocm6.4` makes the tool venv resolve torch from the ROCm index.

Fixing the device then exposed a **second, unrelated breakage**: `xxhash` 4.0 dropped implicit str encoding, and lighteval hashes `doc.query` directly (`logging/info_loggers.py:272`), so a fresh resolve picks up `xxhash 4.0.1` and every run dies just after `COMPUTING METRICS`:

```
hash.example = xxhash.xxh64(doc.query).hexdigest()
TypeError: Strings must be encoded before hashing
```

This is independent of lighteval's version — v0.13.0 and main both hit it. The only reason it isn't already visible is that the June image happened to resolve an older xxhash. `--with "xxhash<4"` holds it back. Without it, rebuilding this image would trade a CPU-fallback bug for a crash-at-the-end bug.

## Verification

On LUMI `dev-g` (MI250X), installing exactly what this def now specifies:

```
torch 2.9.1+rocm6.4 | hip 6.4.43484 | cuda None | xxhash 3.8.1

gathered_tensor tensor([0], device='cuda:0')
Using Data Parallelism, putting model on device cuda

|    Task    |Metric|Value|   |Stderr|
|winogrande:0|acc   |0.125|±  | 0.125|
EXIT=0
```

The same command on the same node before the change reported `device cpu`. I also confirmed each half separately: ROCm backend alone fixes the device but still crashes on xxhash 4.0.1; `xxhash<4` alone leaves it on CPU.

Only `lumi.def` is touched — the other five defs use NVIDIA base images (`nvcr.io/nvidia/pytorch`) where the default CUDA wheel is correct.

## Note

`.sif` itself has not been changed